### PR TITLE
Fix Firebase CLI authentication for Workload Identity Federation

### DIFF
--- a/.github/workflows/firebase-hosting-deploy.yml
+++ b/.github/workflows/firebase-hosting-deploy.yml
@@ -1,21 +1,17 @@
 name: Deploy to Firebase App Hosting on Production Push
-
 on:
   push:
     branches:
       - production
-
 jobs:
   build_and_deploy_prod:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write # This permission is essential for Workload Identity Federation!
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - id: auth
         name: Authenticate to Google Cloud (Workload Identity Federation)
         uses: google-github-actions/auth@v2
@@ -23,47 +19,28 @@ jobs:
           workload_identity_provider: 'projects/371246421587/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
           service_account: 'github-actions-apphosting@joaquin-q0wvv.iam.gserviceaccount.com'
           create_credentials_file: true # This creates the WIF credentials file and sets GOOGLE_APPLICATION_CREDENTIALS
-
-      # --- REMOVE THE 'Verify GCloud Authentication Context' debug step if still present ---
-      # Its job is done, it confirmed our WIF setup works and where the problem was!
-
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '18'
           cache: npm
-
       - name: Install dependencies
         run: npm ci
-
       - name: Build project
         run: npm run build
-
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
-
-      # --- NEW CRITICAL STEP: Configure gcloud context for Firebase CLI ---
-      - name: Configure gcloud context for Firebase CLI
+      - name: Authenticate Firebase CLI with ADC
         run: |
-          # Set the active project for gcloud.
-          gcloud config set project joaquin-q0wvv
-          # Set the active account for gcloud using the service account email.
-          # This should implicitly use the credentials file set by GOOGLE_APPLICATION_CREDENTIALS.
-          gcloud config set account github-actions-apphosting@joaquin-q0wvv.iam.gserviceaccount.com
-          # Optionally, verify the context (for debugging only, can remove later)
-          echo "gcloud context after configuration:"
-          gcloud auth list
-          gcloud config list project
-      # --- END NEW CRITICAL STEP ---
-
-      # --- REMOVE THE 'Generate Firebase Access Token' step ---
-      # We will rely on Firebase picking up ADC through the gcloud context.
-      # And remove the 'env: FIREBASE_TOKEN' from the Trigger step.
-
+          # The google-github-actions/auth action has set up Application Default Credentials (ADC)
+          # Firebase CLI will automatically use these credentials when GOOGLE_APPLICATION_CREDENTIALS is set
+          # We just need to verify the authentication is working
+          firebase --version
+          firebase projects:list
+          echo "Firebase CLI authenticated successfully using Application Default Credentials"
       - name: Trigger App Hosting Rollout
-        # The Firebase CLI should now pick up the authentication from the gcloud context.
-        # No need for FIREBASE_TOKEN env var, or --project flag (as it's set in gcloud config).
         run: |
           firebase apphosting:rollouts:create joaquin-prod \
+            --project joaquin-q0wvv \
             --git-branch=${{ github.ref_name }} \
             --git-commit=${{ github.sha }}

--- a/.github/workflows/firebase-hosting-deploy.yml
+++ b/.github/workflows/firebase-hosting-deploy.yml
@@ -30,17 +30,8 @@ jobs:
         run: npm run build
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
-      - name: Authenticate Firebase CLI with ADC
+      - name: Deploy to Firebase App Hosting
         run: |
-          # The google-github-actions/auth action has set up Application Default Credentials (ADC)
-          # Firebase CLI will automatically use these credentials when GOOGLE_APPLICATION_CREDENTIALS is set
-          # We just need to verify the authentication is working
-          firebase --version
-          firebase projects:list
-          echo "Firebase CLI authenticated successfully using Application Default Credentials"
-      - name: Trigger App Hosting Rollout
-        run: |
-          firebase apphosting:rollouts:create joaquin-prod \
-            --project joaquin-q0wvv \
-            --git-branch=${{ github.ref_name }} \
-            --git-commit=${{ github.sha }}
+          # Firebase CLI automatically uses Application Default Credentials
+          # No gcloud config or manual authentication needed
+          firebase apphosting:backends:deploy --project joaquin-q0wvv


### PR DESCRIPTION
This PR fixes the Firebase CLI authentication in the GitHub Actions workflow for production deployments.

## Changes Made:
- Simplified Firebase CLI authentication to use Application Default Credentials automatically
- Removed unnecessary gcloud configuration steps that were causing authentication issues
- Streamlined the deployment process from `apphosting:rollouts:create` to `apphosting:backends:deploy`
- Cleaned up debug comments and redundant configuration

## Benefits:
- More reliable authentication using Workload Identity Federation
- Simplified workflow with fewer potential failure points
- Better alignment with Firebase CLI best practices

This should resolve the authentication issues we've been experiencing with production deployments.